### PR TITLE
Crude exercise of DS18B20 sensors

### DIFF
--- a/components/temperature-sensor/CMakeLists.txt
+++ b/components/temperature-sensor/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRCS "temperatureSensor.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES "esp32-ds18b20"
+                       PRIV_REQUIRES "esp32-owb")

--- a/components/temperature-sensor/include/temperatureSensor.h
+++ b/components/temperature-sensor/include/temperatureSensor.h
@@ -1,0 +1,58 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Michael Volk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Derived the MIT-licensed work of David Antliff
+ * https://github.com/DavidAntliff/esp32-ds18b20-example
+ * Original license reproduced above; original copyright reproduced below:
+ * Copyright (c) 2017 David Antliff
+ */
+
+#ifndef TEMPERATURE_SENSOR_H
+#define TEMPERATURE_SENSOR_H
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "driver/rmt.h"
+#include "ds18b20.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    const char * name;
+    int oneWireGPIO;
+    rmt_channel_t tx_channel;
+    rmt_channel_t rx_channel;
+    DS18B20_RESOLUTION resolution;
+    QueueHandle_t queue;
+} TemperatureSensor_t;
+
+void senseTemperature(void * pvParameters);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TEMPERATURE_SENSOR_H

--- a/components/temperature-sensor/temperatureSensor.c
+++ b/components/temperature-sensor/temperatureSensor.c
@@ -1,0 +1,110 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Michael Volk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Derived the MIT-licensed work of David Antliff
+ * https://github.com/DavidAntliff/esp32-ds18b20-example
+ * Original license reproduced above; original copyright reproduced below:
+ * Copyright (c) 2017 David Antliff
+ */
+
+#include "temperatureSensor.h"
+#include "owb.h"
+#include "owb_rmt.h"
+#include "freertos/task.h"
+
+void senseTemperature(void * pvParameters) {
+    TemperatureSensor_t * sensor = (TemperatureSensor_t *) pvParameters;
+
+    // Stable readings require a brief period before communication
+    vTaskDelay(2000.0 / portTICK_PERIOD_MS);
+
+    // Create a 1-Wire bus, using the RMT timeslot driver
+    OneWireBus * owb;
+    owb_rmt_driver_info rmt_driver_info;
+    owb = owb_rmt_initialize(&rmt_driver_info, sensor->oneWireGPIO, sensor->tx_channel, sensor->rx_channel);
+    owb_use_crc(owb, true);  // enable CRC check for ROM code
+
+    // Find connected device
+    printf("Find %s device:\n", sensor->name);
+    // OneWireBus_ROMCode device_rom_code;
+    int num_devices = 0;
+    OneWireBus_SearchState search_state = {0};
+    bool found = false;
+    owb_search_first(owb, &search_state, &found);
+    while (found)
+    {
+        char rom_code_s[17];
+        owb_string_from_rom_code(search_state.rom_code, rom_code_s, sizeof(rom_code_s));
+        printf("  %d : %s\n", num_devices, rom_code_s);
+        // if (num_devices == 0) {
+        //     device_rom_code = search_state.rom_code;
+        // }
+        ++num_devices;
+        owb_search_next(owb, &search_state, &found);
+    }
+    printf("Found %d %s device%s\n", num_devices, sensor->name, num_devices == 1 ? "" : "s");
+
+    // For a single device only:
+    OneWireBus_ROMCode rom_code;
+    owb_status status = owb_read_rom(owb, &rom_code);
+    if (status == OWB_STATUS_OK)
+    {
+        char rom_code_s[OWB_ROM_CODE_STRING_LENGTH];
+        owb_string_from_rom_code(rom_code, rom_code_s, sizeof(rom_code_s));
+        printf("Single %s device %s present\n", sensor->name, rom_code_s);
+    }
+    else
+    {
+        printf("An error occurred reading ROM code for %s: %d\n", sensor->name, status);
+    }
+
+    DS18B20_Info * device = ds18b20_malloc();
+    printf("Single device optimisations enabled for %s\n", sensor->name);
+    ds18b20_init_solo(device, owb);
+    ds18b20_use_crc(device, true);
+    ds18b20_set_resolution(device, sensor->resolution);
+
+    int error_count = 0;
+    int sample_count = 0;
+    while (true) {
+        ds18b20_convert_all(owb);
+
+        // In this application all devices use the same resolution,
+        // so use the first device to determine the delay
+        ds18b20_wait_for_conversion(device);
+
+        // Read the results immediately after conversion otherwise it may fail
+        // (using printf before reading may take too long)
+        float reading;
+        if (ds18b20_read_temp(device, &reading) != DS18B20_OK) {
+            ++error_count;
+        }
+
+        // Print results in a separate loop, after all have been read
+        printf("%s sample %d: %.3f C (%d errors)\n", sensor->name, ++sample_count, reading, error_count);
+
+        if (xQueueSend(sensor->queue, &reading, 250.0 / portTICK_PERIOD_MS) != pdTRUE) {
+            printf("FAILED to enqueue reading for %s\n", sensor->name);
+        }
+    }
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,1 @@
-set(COMPONENT_SRCDIRS ".")
-set(COMPONENT_ADD_INCLUDEDIRS ".")
-
-register_component()
+idf_component_register(SRCS "main.c")

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,27 @@
+menu "pipsqueak-rtos Configuration"
+
+  config EXTERNAL_DS18B20_GPIO
+    int "1-Wire GPIO for external DS18B20 temperature sensor"
+  range 0 33
+  default 18
+  help
+    GPIO number (IOxx) to access the One Wire Bus to which the external temperature
+    sensor - and only the external temperature sensor - is connected.
+
+    Some GPIOs are used for other purposes (flash connections, etc.) and cannot be used.
+
+    GPIOs 34-39 are input-only so cannot be used to drive the One Wire Bus.
+
+config INTERNAL_DS18B20_GPIO
+    int "1-Wire GPIO for internal (on-board) DS18B20 temperature sensor"
+  range 0 33
+  default 19
+  help
+    GPIO number (IOxx) to access the One Wire Bus to which the internal temperature
+    sensor - and only the internal temperature sensor - is connected.
+
+    Some GPIOs are used for other purposes (flash connections, etc.) and cannot be used.
+
+    GPIOs 34-39 are input-only so cannot be used to drive the One Wire Bus.
+
+  endmenu

--- a/main/main.c
+++ b/main/main.c
@@ -1,40 +1,89 @@
-/* Hello World Example
-
-   This example code is in the Public Domain (or CC0 licensed, at your option.)
-
-   Unless required by applicable law or agreed to in writing, this
-   software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-   CONDITIONS OF ANY KIND, either express or implied.
-*/
-#include <stdio.h>
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Michael Volk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/queue.h"
+#include "driver/gpio.h"
+#include "driver/rmt.h"
 #include "esp_system.h"
 #include "esp_spi_flash.h"
+#include "temperatureSensor.h"
 
+typedef struct
+{
+    const char * name;
+    QueueHandle_t queue;
+} TemperatureFeed_t;
+
+uint8_t externalSensorData[2 * sizeof(float)];
+StaticQueue_t externalSensorQueue;
+TemperatureSensor_t externalSensor;
+TemperatureFeed_t externalTemperatureFeed;
+
+uint8_t internalSensorData[2 * sizeof(float)];
+StaticQueue_t internalSensorQueue;
+TemperatureSensor_t internalSensor;
+TemperatureFeed_t internalTemperatureFeed;
+
+void consumeTemperature(void * pvParameters) {
+    TemperatureFeed_t * feed = (TemperatureFeed_t *) pvParameters;
+    QueueHandle_t queue = feed->queue;
+    float reading;
+    while (true) {
+      if (xQueueReceive(queue, &reading, 5000.0 / portTICK_PERIOD_MS) == pdTRUE) {
+          printf("CONSUMED: %.3f C from %s\n", reading, feed->name);
+      } else {
+          printf("FAILED to read from %s queue (empty?)\n", feed->name);
+      }
+    }
+}
 
 void app_main(void)
 {
-    printf("Hello world!\n");
+    externalSensor.name = "External sensor";
+    externalSensor.oneWireGPIO = (CONFIG_EXTERNAL_DS18B20_GPIO);
+    externalSensor.tx_channel = RMT_CHANNEL_0;
+    externalSensor.rx_channel = RMT_CHANNEL_1;
+    externalSensor.resolution = DS18B20_RESOLUTION_12_BIT;
+    QueueHandle_t externalTemperatureQueue = xQueueCreateStatic(2, sizeof(float), externalSensorData, &externalSensorQueue);
+    externalSensor.queue = externalTemperatureQueue;
+    xTaskCreate(&senseTemperature, "senseExternalTemperatureTask", 2048, &externalSensor, 5, NULL);
 
-    /* Print chip information */
-    esp_chip_info_t chip_info;
-    esp_chip_info(&chip_info);
-    printf("This is ESP32 chip with %d CPU cores, WiFi%s%s, ",
-            chip_info.cores,
-            (chip_info.features & CHIP_FEATURE_BT) ? "/BT" : "",
-            (chip_info.features & CHIP_FEATURE_BLE) ? "/BLE" : "");
+    externalTemperatureFeed.queue = externalTemperatureQueue;
+    externalTemperatureFeed.name = "External sensor";
+    xTaskCreate(&consumeTemperature, "externalTemperatureConsumeTask", 2048, &externalTemperatureFeed, 5, NULL);
 
-    printf("silicon revision %d, ", chip_info.revision);
+    internalSensor.name = "Internal sensor";
+    internalSensor.oneWireGPIO = (CONFIG_INTERNAL_DS18B20_GPIO);
+    internalSensor.tx_channel = RMT_CHANNEL_2;
+    internalSensor.rx_channel = RMT_CHANNEL_3;
+    internalSensor.resolution = DS18B20_RESOLUTION_9_BIT;
+    QueueHandle_t internalTemperatureQueue = xQueueCreateStatic(2, sizeof(float), internalSensorData, &internalSensorQueue);
+    internalSensor.queue = internalTemperatureQueue;
+    xTaskCreate(&senseTemperature, "senseInternalTemperatureTask", 2048, &internalSensor, 5, NULL);
 
-    printf("%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
-            (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
-
-    for (int i = 10; i >= 0; i--) {
-        printf("Restarting in %d seconds...\n", i);
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
-    }
-    printf("Restarting now.\n");
-    fflush(stdout);
-    esp_restart();
+    internalTemperatureFeed.queue = internalTemperatureQueue;
+    internalTemperatureFeed.name = "Internal sensor";
+    xTaskCreate(&consumeTemperature, "internalTemperatureConsumeTask", 2048, &internalTemperatureFeed, 5, NULL);
 }


### PR DESCRIPTION
# What
Removes "blink" and adds crude but functional temperature sensing and consuming tasks. Sensing is broken out from consuming, with readings pushed over a queue between the paired producer (a component driving a DS18B20 sensor) and consumer (right now simply a stub that prints what it consumes). Includes configurable GPIO pins and support for multiple sensors (ala onboard for system hardware temperature monitoring and remote for a ferment).

# Testing
Tested on breadboarded setup with two sensors, one each on the default GPIOs. I have not attempted to put the two sensors on the same GPIO - and probably won't, since there are plenty of GPIOs available and the conversion times for the two as used on Pipsqueaks is very different between the two sensors.