### PR TITLE
Add clock-keeping logic

### DIFF
--- a/components/esp32-ds3231/CMakeLists.txt
+++ b/components/esp32-ds3231/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "ds3231.c"
+                       INCLUDE_DIRS "include")

--- a/components/esp32-ds3231/ds3231.c
+++ b/components/esp32-ds3231/ds3231.c
@@ -1,0 +1,273 @@
+/*
+ * Stripped-down ESP-IDF driver for DS3231 high precision RTC module
+ *
+ * Amended from https://github.com/UncleRus/esp-idf-lib/blob/master/components/ds3231,
+ * which in turn was ported from esp-open-rtos, and from
+ * https://github.com/UncleRus/esp-idf-lib/blob/master/components/i2cdev
+ *
+ * In broad brush strokes, amendments include:
+ * - Removal of alarm, square wave generator, 32kHz oscillator features
+ * - Removal of features permitting reading of the internal temperature
+ * - Removes support for platforms other than ESP32
+ * - Removes thread safety and rests directly on the ESP-IDF I2C library. If multiple tasks
+ *   are to exercise a single I2C port, external synchronization (mutex/semaphore) is
+ *   required.
+ * - Removes some runtime argument checking
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (C) 2015 Richard A Burton <richardaburton@gmail.com>
+ * Copyright (C) 2016 Bhuvanchandra DV <bhuvanchandra.dv@gmail.com>
+ * Copyright (C) 2018 Ruslan V. Uss <unclerus@gmail.com>
+ * Copyright (C) 2018 Ruslan V. Uss <https://github.com/UncleRus>
+ * Copyright (C) 2020 Michael Volk <michael-volk@hotmail.com>
+ */
+
+#include "ds3231.h"
+#include <string.h>
+#include <esp_log.h>
+
+static const char *TAG = "DS3231";
+
+#define DS3231_I2C_ADDR 0x68
+#define MAX_APB_TIMEOUT 1048575
+
+typedef struct {
+    i2c_config_t config;
+    bool installed;
+} i2c_port_state_t;
+
+static i2c_port_state_t states[I2C_NUM_MAX];
+
+static uint8_t bcd2dec(uint8_t val)
+{
+    return (val >> 4) * 10 + (val & 0x0f);
+}
+
+static uint8_t dec2bcd(uint8_t val)
+{
+    return ((val / 10) << 4) + (val % 10);
+}
+
+inline static bool cfg_equal(const i2c_config_t *a, const i2c_config_t *b)
+{
+    return a->scl_io_num == b->scl_io_num
+        && a->sda_io_num == b->sda_io_num
+        && a->master.clk_speed == b->master.clk_speed
+        && a->scl_pullup_en == b->scl_pullup_en
+        && a->sda_pullup_en == b->sda_pullup_en;
+}
+
+static esp_err_t i2c_setup_port(i2c_port_t port, const i2c_config_t *cfg)
+{
+    esp_err_t res;
+    if (!cfg_equal(cfg, &states[port].config))
+    {
+        ESP_LOGD(TAG, "Reconfiguring I2C driver on port %d", port);
+        i2c_config_t temp;
+        memcpy(&temp, cfg, sizeof(i2c_config_t));
+        temp.mode = I2C_MODE_MASTER;
+
+        // Driver reinstallation
+        if (states[port].installed) {
+            if ((res = i2c_driver_delete(port)) != ESP_OK)
+                return res;
+            states[port].installed = false;
+        }
+        if ((res = i2c_param_config(port, &temp)) != ESP_OK)
+            return res;
+        if ((res = i2c_driver_install(port, temp.mode, 0, 0, 0)) != ESP_OK)
+            return res;
+        // see https://github.com/espressif/esp-idf/issues/680
+        if ((res = i2c_set_timeout(port, MAX_APB_TIMEOUT)) != ESP_OK) {
+            i2c_driver_delete(port);
+            return res;
+        }
+        states[port].installed = true;
+
+        memcpy(&states[port].config, &temp, sizeof(i2c_config_t));
+        ESP_LOGD(TAG, "I2C driver successfully reconfigured on port %d", port);
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t i2c_read_reg(const DS3231_Info *ds3231, uint8_t reg, const void *in_data, size_t in_size)
+{
+    esp_err_t res = i2c_setup_port(ds3231->port, &ds3231->cfg);
+    if (res == ESP_OK)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, ds3231->addr << 1, true);
+        i2c_master_write(cmd, (void *)&reg, 1, true);
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, (ds3231->addr << 1) | 1, true);
+        i2c_master_read(cmd, (void *)in_data, in_size, I2C_MASTER_LAST_NACK);
+        i2c_master_stop(cmd);
+
+        res = i2c_master_cmd_begin(ds3231->port, cmd, ds3231->timeoutMs / portTICK_RATE_MS);
+        if (res != ESP_OK)
+            ESP_LOGE(TAG, "Could not read from device [0x%02x at %d]: %d", ds3231->addr, ds3231->port, res);
+
+        i2c_cmd_link_delete(cmd);
+    }
+    return res;
+}
+
+esp_err_t i2c_write_reg(const DS3231_Info *ds3231, uint8_t reg, const void *data, size_t size)
+{
+    esp_err_t res = i2c_setup_port(ds3231->port, &ds3231->cfg);
+    if (res == ESP_OK)
+    {
+        i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+        i2c_master_start(cmd);
+        i2c_master_write_byte(cmd, ds3231->addr << 1, true);
+        i2c_master_write(cmd, (void *)&reg, 1, true);
+        i2c_master_write(cmd, (void *)data, size, true);
+        i2c_master_stop(cmd);
+        res = i2c_master_cmd_begin(ds3231->port, cmd, ds3231->timeoutMs / portTICK_RATE_MS);
+        if (res != ESP_OK)
+            ESP_LOGE(TAG, "Could not write to device [0x%02x at %d]: %d", ds3231->addr, ds3231->port, res);
+        i2c_cmd_link_delete(cmd);
+    }
+    return res;
+}
+
+void ds3231_init_info(DS3231_Info *ds3231, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio, uint32_t timeoutMs)
+{
+    ds3231->port = port;
+    ds3231->addr = DS3231_I2C_ADDR;
+    ds3231->timeoutMs = timeoutMs;
+    ds3231->cfg.sda_io_num = sda_gpio;
+    ds3231->cfg.scl_io_num = scl_gpio;
+    ds3231->cfg.sda_pullup_en = GPIO_PULLUP_DISABLE;
+    ds3231->cfg.scl_pullup_en = GPIO_PULLUP_DISABLE;
+    ds3231->cfg.master.clk_speed = I2C_FREQ_HZ;
+}
+
+esp_err_t ds3231_set_time(DS3231_Info *ds3231, struct tm *time)
+{
+    uint8_t data[7];
+
+    /* time/date data */
+    data[0] = dec2bcd(time->tm_sec);
+    data[1] = dec2bcd(time->tm_min);
+    data[2] = dec2bcd(time->tm_hour);
+    /* The week data must be in the range 1 to 7, and to keep the start on the
+     * same day as for tm_wday have it start at 1 on Sunday. */
+    data[3] = dec2bcd(time->tm_wday + 1);
+    data[4] = dec2bcd(time->tm_mday);
+    data[5] = dec2bcd(time->tm_mon + 1);
+    data[6] = dec2bcd(time->tm_year - 100);
+
+    i2c_write_reg(ds3231, DS3231_ADDR_TIME, data, 7);
+
+    return ESP_OK;
+}
+
+/* Get a byte containing just the requested bits
+ * pass the register address to read, a mask to apply to the register and
+ * an uint* for the output
+ * you can test this value directly as true/false for specific bit mask
+ * of use a mask of 0xff to just return the whole register byte
+ * returns true to indicate success
+ */
+static esp_err_t ds3231_get_flag(DS3231_Info *ds3231, uint8_t addr, uint8_t mask, uint8_t *flag)
+{
+    uint8_t data;
+
+    /* get register */
+    esp_err_t res = i2c_read_reg(ds3231, addr, &data, 1);
+    if (res != ESP_OK)
+        return res;
+
+    /* return only requested flag */
+    *flag = (data & mask);
+    return ESP_OK;
+}
+
+/* Set/clear bits in a byte register, or replace the byte altogether
+ * pass the register address to modify, a byte to replace the existing
+ * value with or containing the bits to set/clear and one of
+ * DS3231_SET/DS3231_CLEAR/DS3231_REPLACE
+ * returns true to indicate success
+ */
+static esp_err_t ds3231_set_flag(DS3231_Info *ds3231, uint8_t addr, uint8_t bits, uint8_t mode)
+{
+    uint8_t data;
+
+    /* get status register */
+    esp_err_t res = i2c_read_reg(ds3231, addr, &data, 1);
+    if (res != ESP_OK)
+        return res;
+    /* clear the flag */
+    if (mode == DS3231_REPLACE)
+        data = bits;
+    else if (mode == DS3231_SET)
+        data |= bits;
+    else
+        data &= ~bits;
+
+    return i2c_write_reg(ds3231, addr, &data, 1);
+}
+
+esp_err_t ds3231_get_oscillator_stop_flag(DS3231_Info *ds3231, bool *flag)
+{
+    uint8_t f;
+    ds3231_get_flag(ds3231, DS3231_ADDR_STATUS, DS3231_STAT_OSCILLATOR, &f);
+    *flag = (f ? true : false);
+    return ESP_OK;
+}
+
+esp_err_t ds3231_clear_oscillator_stop_flag(DS3231_Info *ds3231)
+{
+    ds3231_set_flag(ds3231, DS3231_ADDR_STATUS, DS3231_STAT_OSCILLATOR, DS3231_CLEAR);
+    return ESP_OK;
+}
+
+esp_err_t ds3231_get_time(DS3231_Info *ds3231, struct tm *time)
+{
+    uint8_t data[7];
+
+    /* read time */
+    i2c_read_reg(ds3231, DS3231_ADDR_TIME, data, 7);
+
+    /* convert to unix time structure */
+    time->tm_sec = bcd2dec(data[0]);
+    time->tm_min = bcd2dec(data[1]);
+    if (data[2] & DS3231_12HOUR_FLAG)
+    {
+        /* 12H */
+        time->tm_hour = bcd2dec(data[2] & DS3231_12HOUR_MASK) - 1;
+        /* AM/PM? */
+        if (data[2] & DS3231_PM_FLAG) time->tm_hour += 12;
+    }
+    else time->tm_hour = bcd2dec(data[2]); /* 24H */
+    time->tm_wday = bcd2dec(data[3]) - 1;
+    time->tm_mday = bcd2dec(data[4]);
+    time->tm_mon  = bcd2dec(data[5] & DS3231_MONTH_MASK) - 1;
+    time->tm_year = bcd2dec(data[6]) + 100;
+    time->tm_isdst = 0;
+
+    return ESP_OK;
+}

--- a/components/esp32-ds3231/include/ds3231.h
+++ b/components/esp32-ds3231/include/ds3231.h
@@ -1,0 +1,133 @@
+/*
+ * Stripped-down ESP32-specific ESP-IDF driver for DS3231 high precision RTC module
+ *
+ * Amended from https://github.com/UncleRus/esp-idf-lib/blob/master/components/ds3231,
+ * which in turn was ported from esp-open-rtos, and from
+ * https://github.com/UncleRus/esp-idf-lib/blob/master/components/i2cdev
+ *
+ * In broad brush strokes, amendments include:
+ * - Removal of alarm, square wave generator, 32kHz oscillator features
+ * - Removal of features permitting reading of the internal temperature
+ * - Removes support for platforms other than ESP32
+ * - Removes thread safety and rests directly on the ESP-IDF I2C library. If multiple tasks
+ *   are to exercise a single I2C port, external synchronization (mutex/semaphore) is
+ *   required.
+ * - Removes some runtime argument checking
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ * Copyright (C) 2015 Richard A Burton <richardaburton@gmail.com>
+ * Copyright (C) 2016 Bhuvanchandra DV <bhuvanchandra.dv@gmail.com>
+ * Copyright (C) 2018 Ruslan V. Uss <unclerus@gmail.com
+ * Copyright (C) 2018 Ruslan V. Uss <https://github.com/UncleRus>
+ * Copyright (C) 2020 Michael Volk <michael-volk@hotmail.com>
+ */
+
+#ifndef DS3231_H
+#define DS3231_H
+
+#include <esp_err.h>
+#include <driver/i2c.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define I2C_FREQ_HZ               400000
+
+#define DS3231_STAT_OSCILLATOR    0x80
+
+#define DS3231_ADDR_TIME          0x00
+#define DS3231_ADDR_CONTROL       0x0e
+#define DS3231_ADDR_STATUS        0x0f
+
+#define DS3231_12HOUR_FLAG        0x40
+#define DS3231_12HOUR_MASK        0x1f
+#define DS3231_PM_FLAG            0x20
+#define DS3231_MONTH_MASK         0x1f
+
+enum {
+    DS3231_SET = 0,
+    DS3231_CLEAR,
+    DS3231_REPLACE
+};
+
+typedef struct {
+    i2c_port_t port;
+    i2c_config_t cfg;
+    uint8_t addr;
+    uint32_t timeoutMs;
+} DS3231_Info;
+
+/**
+ * @brief Initialize device descriptor
+ * @param ds3231 DS3231 device descriptor
+ * @param port I2C port - I2C_NUM_0 or I2C_NUM_1
+ * @param sda_gpio SDA GPIO
+ * @param scl_gpio SCL GPIO
+ * @param timeoutMS timeout for message transmissions
+ */
+void ds3231_init_info(DS3231_Info *ds3231, i2c_port_t port, gpio_num_t sda_gpio, gpio_num_t scl_gpio, uint32_t timeoutMs);
+
+/**
+ * @brief Set the time on the RTC
+ *
+ * Timezone agnostic, pass whatever you like.
+ * I suggest using GMT and applying timezone and DST when read back.
+ *
+ * @return ESP_OK to indicate success
+ */
+esp_err_t ds3231_set_time(DS3231_Info *ds3231, struct tm *time);
+
+/**
+ * @brief Get the time from the RTC, populates a supplied tm struct
+ * @param dev Device descriptor
+ * @param[out] time RTC time
+ * @return ESP_OK to indicate success
+ */
+esp_err_t ds3231_get_time(DS3231_Info *ds3231, struct tm *time);
+
+/**
+ * @brief Check if oscillator has previously stopped
+ *
+ * E.g. no power/battery or disabled
+ * sets flag to true if there has been a stop
+ *
+ * @param dev Device descriptor
+ * @param[out] flag Stop flag
+ * @return ESP_OK to indicate success
+ */
+esp_err_t ds3231_get_oscillator_stop_flag(DS3231_Info *ds3231, bool *flag);
+
+/**
+ * @brief Clear the oscillator stopped flag
+ * @param dev Device descriptor
+ * @return ESP_OK to indicate success
+ */
+esp_err_t ds3231_clear_oscillator_stop_flag(DS3231_Info *ds3231);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DS3231_H

--- a/components/psq4-timekeeper/CMakeLists.txt
+++ b/components/psq4-timekeeper/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "timekeeper.c"
+                       INCLUDE_DIRS "include"
+                       REQUIRES "esp32-ds3231")

--- a/components/psq4-timekeeper/include/timekeeper.h
+++ b/components/psq4-timekeeper/include/timekeeper.h
@@ -1,0 +1,61 @@
+/*
+ * Periodically synchronizes the system time to a peripheral DS3231 real time
+ * clock.
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright (c) 2020 Michael Volk
+ */
+
+#ifndef TIMEKEEPER_H
+#define TIMEKEEPER_H
+
+#include <sys/time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief A task that maintains the system clock.
+ *
+ * Immediately sets the system timezone, synchronizes the ESP's RTC to the
+ * time more precisely and persistently maintained by an external DS3231 RTC,
+ * checks to see if the external RTC's battery might have died and sets up
+ * syncing of both the system RTC and external RTC with NTP.
+ *
+ * Infrequently updates the system time to match the external RTC time.
+ *
+ * @param ds3231 DS3231 device descriptor
+ */
+void timekeeper_task(void * pvParameters);
+
+/**
+ * @brief Returns the current unix timestamp.
+ * @return The number of seconds since Jan 1 1970 at midnight UTC
+ */
+time_t unix_timestamp();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TIMEKEEPER_H

--- a/components/psq4-timekeeper/timekeeper.c
+++ b/components/psq4-timekeeper/timekeeper.c
@@ -1,0 +1,113 @@
+#include "timekeeper.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <string.h>
+#include <time.h>
+#include <esp_log.h>
+#include <esp_sntp.h>
+#include <ds3231.h>
+
+// We read to whole second resolution, meaning that at the moment we get
+// "48 seconds" (for example) as the second of the minute, it is at least
+// 48 but could be as much as 48.9999. Assuming the processing time is
+// negligible, if we guess that the actual time is Ts.5, where "Ts" is
+// the whole number of seconds we read, then we should be off by no more
+// than half a second plus or minus between the two clocks.
+#define USEC_GUESS 500000
+
+#define ONE_MINUTE 60 // in seconds
+#define ONE_HOUR 3600 // in seconds
+#define MS_FACTOR 1000.0
+
+const char * TAG = "timekeeper";
+
+static time_t last_sync_from_sntp = 0;
+static time_t last_sync_from_rtc = 0;
+static time_t last_sync_of_rtc = 0;
+
+time_t unix_timestamp() {
+  time_t now;
+  time(&now);
+  return now;
+}
+
+void sync_from_external_rtc(DS3231_Info *ds3231) {
+    struct tm time;
+    struct timezone tz = { 0, 0 };
+    ds3231_get_time(ds3231, &time);
+    time_t now = mktime(&time);
+    struct timeval tv = { now, USEC_GUESS };
+    settimeofday(&tv, &tz);
+    last_sync_from_rtc = now;
+    ESP_LOGD(TAG, "Internal clock synced to external RTC; unix_timestamp=%ld", now);
+}
+
+void sync_to_external_rtc(DS3231_Info *ds3231) {
+  struct tm time;
+  time_t now = unix_timestamp();
+  memcpy(&time, localtime(&now), sizeof(struct tm));
+  ds3231_set_time(ds3231, &time);
+  last_sync_of_rtc = now;
+  ESP_LOGD(TAG, "External RTC synced to internal clock; unix_timestamp=%ld", now);
+}
+
+void sntp_sync_notification_cb(struct timeval *tv)
+{
+    last_sync_from_sntp = unix_timestamp();
+    ESP_LOGD(TAG, "Internal clock synchronized via SNTP; unix_timestamp=%ld", last_sync_from_sntp);
+}
+
+void set_up_sntp() {
+    sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    sntp_setservername(0, "pool.ntp.org");
+    sntp_set_time_sync_notification_cb(sntp_sync_notification_cb);
+#ifdef CONFIG_SNTP_TIME_SYNC_METHOD_SMOOTH
+    sntp_set_sync_mode(SNTP_SYNC_MODE_SMOOTH);
+#endif
+    sntp_init();
+}
+
+void timekeeper_task(void *pvParameters) {
+    DS3231_Info *ds3231 = (DS3231_Info *)pvParameters;
+
+    // Set system timezone to GMT
+    setenv("TZ", "GMT+0", 1);
+    tzset();
+
+    // Set the internal clock using the external RTC
+    sync_from_external_rtc(ds3231);
+
+    // Check to see if the external RTC shut down unexpectedly
+    bool oscillator_stopped;
+    ds3231_get_oscillator_stop_flag(ds3231, &oscillator_stopped);
+    if (oscillator_stopped) {
+        ESP_LOGE(TAG, "DS3231 RTC oscillator stopped, which means that the DS3231's battery is likely dead");
+        ds3231_clear_oscillator_stop_flag(ds3231);
+    }
+
+    // Use SNTP to correct clock drift
+    set_up_sntp();
+
+    // We'll be maintaining time via SNTP with our external RTC for backup.
+    // If we recently got time via SNTP, correct the external RTC's (small) drift
+    // If we haven't recently had an SNTP update,
+    // If we fail to obtain time from
+    // NTP, sync the ESP's clock to the external RTC hourly. This reduces clock
+    // drift if the device cannot obtain an SNTP connection over a long period of
+    // time
+    while(true) {
+        vTaskDelay((ONE_MINUTE * MS_FACTOR) / portTICK_PERIOD_MS);
+        time_t now = unix_timestamp();
+        time_t since_sync_from_sntp = now - last_sync_from_sntp;
+        time_t since_sync_from_rtc = now - last_sync_from_rtc;
+        time_t since_sync_of_rtc = now - last_sync_of_rtc;
+        // Sync the RTC to SNTP if SNTP is working
+        if (since_sync_from_sntp < (5 * ONE_MINUTE) && since_sync_of_rtc > ONE_HOUR) {
+            sync_to_external_rtc(ds3231);
+        }
+        // Sync from RTC if SNTP isn't working out
+        if (since_sync_from_sntp > (2 * ONE_HOUR) && since_sync_from_rtc > ONE_HOUR) {
+            sync_from_external_rtc(ds3231);
+        }
+    }
+}


### PR DESCRIPTION
# What
Adds an I2C-interfaced DS3231 Real Time Clock (RTC). Uses this external RTC to set the system clock on boot and to keep the system clock from drifting too far when SNTP isn't working. Sets up SNTP as well, but that functionality is untested.

# Testing
Verified on an DevKitCv4 using the [Adafruit breakout](https://www.adafruit.com/product/3013). SNTP function has not been verified (no wifi on the test system yet).