### PR TITLE
Retry DS18B20 reads on failure

### DIFF
--- a/components/psq4-system/psq4_thermometers.c
+++ b/components/psq4-system/psq4_thermometers.c
@@ -206,7 +206,7 @@ static void psq4_temperature_sense(void * pvParameters)
                 );
                 continue;
             }
-        } while (status_code != DS18B20_OK && read_attempt < 3);
+        } while (status_code != DS18B20_OK && read_attempt <= 3);
 
         if (status_code == DS18B20_OK ) {
             // Print results in a separate loop, after all have been read


### PR DESCRIPTION
# What
DS18B20 temperature conversion is time consuming, especially with 12-bit resolution (750ms). CRC failures, while infrequent, are a normal part of operation. Retrying the read is much faster than asking for another conversion, so in this change I switch from giving up on 1 failed attempt to retry the read upon failure up to a couple of times before giving up.

# Testing
Compilation verified, but not otherwise verified.